### PR TITLE
Read file artists

### DIFF
--- a/esporifai/utils.py
+++ b/esporifai/utils.py
@@ -1,3 +1,4 @@
+import re
 import json
 from datetime import datetime as dt
 from datetime import timedelta
@@ -185,3 +186,17 @@ def handle_data(
             json.dump(data, file, indent=2, default=str)
 
     return data
+
+
+def handle_id_file(filepath: Path):
+    spotify_id_re = re.compile("[a-zA-Z0-9]{22}")
+    with open(filepath, "r") as file:
+        contents = file.readlines()
+
+    ids = []
+    for line in contents:
+        _id = spotify_id_re.findall(line)
+        if len(_id) > 0:
+            ids.append(_id[0])
+
+    return ids

--- a/tests/test_esporifai.py
+++ b/tests/test_esporifai.py
@@ -1,4 +1,5 @@
 import json
+from pathlib import Path
 
 import pytest
 from typer.testing import CliRunner
@@ -17,7 +18,7 @@ def test_help(options):
     assert "Usage: " in result.output
 
 
-def test_get_analyze_track():
+def test_analyze_track():
     result = runner.invoke(
         cli.cli, ["analyze-track", "4hPl8CtzHoh9LMmKTFyiPl", "--output", "-"]
     )
@@ -26,6 +27,31 @@ def test_get_analyze_track():
     assert "track" in output.keys()
     assert "meta" in output.keys()
     assert "sections" in output.keys()
+
+
+def test_analyze_tracks(tmp_path):
+    track_ids_file = tmp_path.joinpath("track_ids.txt")
+    with open(track_ids_file, "w") as file:
+        file.write("2pEa0vCzu86pDLz9KPDAcg\n")  # Alivianado
+        file.write("2O8aEi9SpwobvFLvKHvIl3\n")  # Estamos Bien
+        file.write("1XReTPKaJypMIXSvOW9YXV\n")  # Semillas
+    runner.invoke(
+        cli.cli,
+        [
+            "analyze-track",
+            "-",
+            "--file",
+            f"{track_ids_file}",
+            "--output",
+            f"{tmp_path}",
+        ],
+    )
+    analysis_files = sorted([file.name for file in tmp_path.glob("*.json")])
+    assert analysis_files == [
+        "1XReTPKaJypMIXSvOW9YXV.json",
+        "2O8aEi9SpwobvFLvKHvIl3.json",
+        "2pEa0vCzu86pDLz9KPDAcg.json",
+    ]
 
 
 def test_get_artist():


### PR DESCRIPTION
Add `--file` option to `analyze-track` command to read a newline-delimited .txt or .csv file with Spotify IDs

```shell
# Pass '-' as the first argument (would be a track id if not using a file)
esporifai analyze-track - --file ids.txt
```